### PR TITLE
Fix commands

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
   discord:
     build: 
       context: ./services/discord
+      target: prod
     image: ccheung22/twitch-bot_discord
     env_file: 
       ./services/discord/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   redis:
-    image: redis:alpine
+    image: redis:6.0.11-alpine
     ports:
       - "6379:6379"
   discord:

--- a/services/discord/Dockerfile
+++ b/services/discord/Dockerfile
@@ -16,7 +16,7 @@ RUN rm -rf node_modules
 RUN npm install --production
 
 ### Production image
-FROM node:12-alpine
+FROM node:12-alpine AS prod
 
 WORKDIR /home/node/twitch-bot
 USER node

--- a/services/discord/src/commands/factory/Explicit.ts
+++ b/services/discord/src/commands/factory/Explicit.ts
@@ -1,9 +1,6 @@
 import { Command } from "../../enum/CommandEnum";
-import { JoinVoiceChannel } from "../explicit/Join";
 import { Message } from "discord.js";
 import { AbstractCommand } from "../AbstractCommand";
-import { Sounds } from "../explicit/Sounds";
-import { CoinFlip } from "../../commands/explicit/CoinFlip";
 import { MuteAll } from "../../commands/explicit/MuteAll";
 import path from "path";
 import fs from "mz/fs";
@@ -25,7 +22,8 @@ const findCommandInDir = async (
   const files = await fs.readdir(explicitDir);
   // Need to somehow initalise the class given the command string
   const match = files.filter(
-    file => file.replace(".ts", "").toLowerCase() === message.content.substr(1)
+    file =>
+      file.replace(/.ts|.js/g, "").toLowerCase() === message.content.substr(1)
   );
   if (match.length > 0) {
     const imports = await import(`../explicit/${match[0]}`);


### PR DESCRIPTION
Fix commands not showing as a result from #55 

This was caused by the code looking for `.ts` . 

During testing we use ts-node-dev for quick builds, but in prod it builds the `.js` files using `tsc`, as a result we fix it by replacing either file types